### PR TITLE
Enable partition projection on Glue tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,3 +158,17 @@ The end result of this is that the client needs two things:
    handbook, and ensure it matches the environment you're deploying to 
    (currently either `development` or `production`). DO NOT LOG TO THE WRONG 
    PLACE
+
+#### Deploying AWS Services
+
+The AWS services are deployed using the CDK. The CDK is a framework for
+defining AWS infrastructure as code. It's written in Python, and the code
+is in the `dc_logging_aws` directory.
+
+Deployment is done automatically by CircleCI. To deploy manually, you need
+to install the CDK and run `cdk deploy` in the root of this repo, with these two
+environment variables set for development (production deploys should be handled
+by CircleCI):
+
+- `DC_ENVIRONMENT`: `development`
+- `LOGS_BUCKET_NAME`: Run `aws s3 ls` to find this, it likely ends with `logging`.


### PR DESCRIPTION
This tells Athena to manage partitions itself via
[Projected Partitions][] rather than requiring us to define every
partition up front in the Glue data catalog.

We also rename the table to be underscored rather than dashed for better
Athena compatibility.

The `TBLPROPERTIES` parameters aren't natively exposed by CDK, so we use
CloudFormation overrides instead for these.

This will give a whole-date partition, so would be queried by:
```sql
WHERE date >= '2023/10/01' AND hour > 10 AND hour < 18
```

We can change this easily to be split by year, month and day if needed.

Deploying this will remove the old table definition and replace it with the newly partitioned one with the new name.


[Projected Partitions]: https://docs.aws.amazon.com/athena/latest/ug/partition-projection.html