### PR TITLE
Compress all files with gzip

### DIFF
--- a/dc_logging_aws/stacks/dc_logs_stack.py
+++ b/dc_logging_aws/stacks/dc_logs_stack.py
@@ -141,6 +141,11 @@ class DCLogsStack(Stack):
                     "org.openx.data.jsonserde.JsonSerDe"
                 ),
             ),
+            storage_parameters=[
+                glue.StorageParameter.compression_type(
+                    glue.CompressionType.GZIP
+                )
+            ],
         )
 
         # Projection isn't supported directly by the CDK, so we have to set
@@ -178,7 +183,9 @@ class DCLogsStack(Stack):
             cls.stream_name,
             destinations=[
                 firehose_destinations.S3Bucket(
-                    self.bucket, data_output_prefix=f"{cls.stream_name}/"
+                    self.bucket,
+                    data_output_prefix=f"{cls.stream_name}/",
+                    compression=firehose_destinations.Compression.GZIP,
                 )
             ],
             delivery_stream_name=cls.stream_name,


### PR DESCRIPTION
Athena detects files with a `.gz` extension and handles them accordingly. Firehose is now configured to spit out gzipped logs.

We also explicitly set the table to be gzip compressed so any data insertion we do in the future results in gzipped files.

