### PR TITLE
remove typing_extensions import

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -14,7 +14,7 @@ name = "pypi"
 cachetools = "==v5.2.0"
 wheel = "==0.38.4"
 dc-logging-utils = {path = "."}
-urllib3 = "<2"
+urllib3 = "==1.26.19"
 
 [dev-packages]
 boto3 = ">=1.20,<1.30"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "6e7d2f9f4f6849e110f8dc15e487f44c97870c1c9ce07b03ee6bb14270ea26c6"
+            "sha256": "2521fed5fbba581f4d57b095dec37b676e17a98ebfaff6c98faa6dfbe9c5e2a3"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -181,11 +181,12 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:34b97092d7e0a3a8cf7cd10e386f401b3737364026c45e622aa02903dffe0f07",
-                "sha256:f8ecc1bba5667413457c529ab955bf8c67b45db799d159066261719e328580a0"
+                "sha256:37a0344459b199fce0e80b0d3569837ec6b6937435c5244e7fd73fa6006830f3",
+                "sha256:3e3d753a8618b86d7de333b4223005f68720bcd6a7d2bcb9fbd2229ec7c1e429"
             ],
             "index": "pypi",
-            "version": "==1.26.18"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
+            "version": "==1.26.19"
         },
         "wheel": {
             "hashes": [

--- a/dc_logging_client/log_client.py
+++ b/dc_logging_client/log_client.py
@@ -3,10 +3,6 @@ import logging
 import os
 
 import boto3
-from typing_extensions import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    pass
 
 from .log_entries import (
     BaseLogEntry,


### PR DESCRIPTION
This package has an undeclared dependency on the typing-extensions package because it imports from `typing_extensions` but `typing-extensions` is not in the project requirements. I was going to add it.

Then I thought about it slightly more: If all we want to import is `TYPE_CHECKING` we shouldn't need `typing_extensions`. `TYPE_CHECKING` is in python core since python 3.5.

Then I thought about it slightly more: If the only thing we're doing with this constant is

```py
if TYPE_CHECKING:
    pass
```

then this entire thing is a no-op and we can just bin all of it.

Right?