### PR TITLE
Add step to move saved CSVs to a known location

### DIFF
--- a/dc_logging_aws/constructs/tasks/postcode_searches_query.py
+++ b/dc_logging_aws/constructs/tasks/postcode_searches_query.py
@@ -1,8 +1,11 @@
 from typing import Optional
 
+from aws_cdk import aws_iam as iam
+from aws_cdk import aws_s3 as s3
 from aws_cdk import aws_stepfunctions as sfn
 from aws_cdk import aws_stepfunctions_tasks as tasks
 from constructs import Construct
+from models.buckets import postcode_searches_results_bucket
 from models.models import BaseQuery
 
 
@@ -78,6 +81,40 @@ class PostcodeSearchesQueryTask(Construct):
             },
         )
 
-        self.task = query_task
+        results_bucket = s3.Bucket.from_bucket_name(
+            self,
+            "results_bucket",
+            postcode_searches_results_bucket.bucket_name,
+        )
+        bucket_name = results_bucket.bucket_name
+        copy_source = (
+            "{% '"
+            + bucket_name
+            + "/postcode-searches-athena-results/' & $"
+            + result_variable_name
+            + " & '.csv' %}"
+        )
+        dest_key = (
+            "{% $polling_day_athena & '/" + result_variable_name + ".csv' %}"
+        )
+        copy_task = tasks.CallAwsService(
+            self,
+            f"{task_name} Copy Result",
+            service="s3",
+            action="copyObject",
+            parameters={
+                "Bucket": bucket_name,
+                "CopySource": copy_source,
+                "Key": dest_key,
+            },
+            iam_resources=[results_bucket.arn_for_objects("*")],
+            additional_iam_statements=[
+                iam.PolicyStatement(
+                    actions=["s3:GetObject"],
+                    resources=[results_bucket.arn_for_objects("*")],
+                )
+            ],
+            query_language=sfn.QueryLanguage.JSONATA,
+        )
 
-        # ToDo: Do something with the result
+        self.task = query_task.next(copy_task)

--- a/dc_logging_aws/lambdas/run_athena_query_and_report_status/handler.py
+++ b/dc_logging_aws/lambdas/run_athena_query_and_report_status/handler.py
@@ -2,6 +2,7 @@
 A generic Lambda that can run an Athena query and wait for it to complete
 
 """
+
 import os
 import time
 

--- a/dc_logging_aws/setup_ssm_with_account_ids.py
+++ b/dc_logging_aws/setup_ssm_with_account_ids.py
@@ -1,6 +1,6 @@
 """
-Run this script as an organisation admin to create the SSM entries in the 
-monitoring accounts 
+Run this script as an organisation admin to create the SSM entries in the
+monitoring accounts
 """
 
 import boto3

--- a/dc_logging_aws/stacks/postcode_searches_stack.py
+++ b/dc_logging_aws/stacks/postcode_searches_stack.py
@@ -91,7 +91,7 @@ class PostcodeSearchesStack(Stack):
             timeout=Duration.minutes(10),
         )
 
-    def query_tasks(self) -> List[tasks.LambdaInvoke]:
+    def query_tasks(self) -> List[sfn.IChainable]:
         return [
             PostcodeSearchesQueryTask(
                 scope=self,


### PR DESCRIPTION
This is a bit hard to test, and there's one complex string formatting thing...

1. I did a dev deploy, but the way this repo is set up makes swapping the bucket names out hard. I get a permissions error when writing to S3 form the dev account because it's trying to write to the prod bucket. This is a good thing and I didn't want to pull the thread of changing buckets based on the env. 
2. `copy_source` is complex because there are two layers of string formatting going on at once. The Python layer and the "JSONATA" (apparently) thing that's used to format inside step functions. It looks right on the dev deploy. 